### PR TITLE
no payload is no error

### DIFF
--- a/addon/adapters/sails-base.js
+++ b/addon/adapters/sails-base.js
@@ -209,7 +209,7 @@ export default DS.RESTAdapter.extend(Ember.Evented, WithLoggerMixin, {
    * @return {Boolean} Returns `true` if it's an error object, else `false`
    */
   isErrorObject: function (data) {
-    return !!(data.error && data.model && data.summary && data.status);
+    return !!(data && data.error && data.model && data.summary && data.status);
   },
 
   /**


### PR DESCRIPTION
When destroying a record, the recommended payload is blank. 
It is the strategy followed by this blueprint : https://github.com/mphasize/sails-generate-ember-blueprints/blob/master/templates/basic/api/blueprints/destroy.js

Currently such an empty response raises an error.