### PR TITLE
Allow for sails.io.js to be installed locally as part of Ember project

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Adapters and tools for Ember to work well with Sails. Provides `SailsSocketServi
 
     In order to use the `SailsSocketService`, you're application will need to load `sails.io.js`. If not otherwise specified, it will be loaded from `//localhost:1337/js/dependencies/sails.io.js`, which is served through Sails by default.
 
-    If you'd like to load `sails.io.js` from an external location, you may specify its path using the `scriptPath` property. This can be changed in your `config/environment.js` file:
+    If you'd like to change the path of your script file *AND* it's still served from your Sails server, you can simply change the `scriptPath` property to a path of your choosing in your `config/environment.js` file:
 
     ```js
     ENV.APP = {
@@ -29,29 +29,23 @@ Adapters and tools for Ember to work well with Sails. Provides `SailsSocketServi
     }
     ```
 
-    Alternatively, you may install `sails.io.js` locally as part of your Ember project. This has the unique benefit of the script being treated like any other in the Ember-CLI asset pipeline. In addition, if you're deploying using [ember-cli-deploy](https://github.com/ember-cli/ember-cli-deploy), you'll get the benefit of having that script reside on a CDN. You can install the script locally like so:
-
-    ```
-    bower install sails.io.js
-    ```
-
-    then adding the following to your `Brocfile.js` or `ember-cli-build.js` (ember-cli >= 1.13):
-
-    ```js
-    app.import(app.bowerDirectory + '/sails.io.js/dist/sails.io.js');
-    ```
-
-    Finally, you'll need to set the `sailsHost` property to the URL of your Sails instance like so:
+    Alternatively, if you'd like to load the script from an external location that is *_NOT_* your Sails server, you may do so using the following properties:
 
     ```js
     // environment.js
     ENV.APP {
       emberDataSails: {
-        // url to your Sails instance
+        // tells ember-data-sails to load an external script
+        loadExternalScript: true,
+        // the url of the script
+        scriptPath: 'https://as889324.maxcdn.com/sails.io.js',
+        // the url to your Sails instance
         sailsHost: "https://localhost:1337"
       }
     }
     ```
+
+    The reason that you must  specify that the script is to be loaded from an external location is because `sails.io.js` will automatically attempt to connect to whatever server the file is loaded by. Therefore, if you're Sails server lives on a different host, other options need to be set to enable cross-domain communication. You can read more [here](https://github.com/balderdashy/sails.io.js#cross-domain).
 
     Also don't forget to add the rules for CSP for wherever you script is hosted:
 

--- a/README.md
+++ b/README.md
@@ -14,19 +14,9 @@ Adapters and tools for Ember to work well with Sails. Provides `SailsSocketServi
       });
     ```
 
-    In order to use the `SailsSocketService`, you're application will need to load `sails.io.js`. This can be installed by running:
+    In order to use the `SailsSocketService`, you're application will need to load `sails.io.js`. If not otherwise specified, it will be loaded from `//localhost:1337/js/dependencies/sails.io.js`, which is served through Sails by default.
 
-    ```
-    bower install sails.io.js
-    ```
-
-    and then adding the following to your `Brocfile.js` or `ember-cli-build.js` (ember-cli >= 1.13):
-
-    ```js
-    app.import(app.bowerDirectory + '/sails.io.js/dist/sails.io.js');
-    ```
-
-    Alternatively, you may specify an alternative path to `sails.io.js` using the `scriptPath` property. This can be changed in your `config/environment.js` file:
+    If you'd like to load `sails.io.js` from an external location, you may specify its path using the `scriptPath` property. This can be changed in your `config/environment.js` file:
 
     ```js
     ENV.APP = {
@@ -35,6 +25,30 @@ Adapters and tools for Ember to work well with Sails. Provides `SailsSocketServi
       emberDataSails:  {
         // Sails serves up sails.io.js by default at the following path
         scriptPath: '//localhost:1337/js/dependencies/sails.io.js'
+      }
+    }
+    ```
+
+    Alternatively, you may install `sails.io.js` locally as part of your Ember project. This has the unique benefit of the script being treated like any other in the Ember-CLI asset pipeline. In addition, if you're deploying using [ember-cli-deploy](https://github.com/ember-cli/ember-cli-deploy), you'll get the benefit of having that script reside on a CDN. You can install the script locally like so:
+
+    ```
+    bower install sails.io.js
+    ```
+
+    then adding the following to your `Brocfile.js` or `ember-cli-build.js` (ember-cli >= 1.13):
+
+    ```js
+    app.import(app.bowerDirectory + '/sails.io.js/dist/sails.io.js');
+    ```
+
+    Finally, you'll need to set the `sailsHost` property to the URL of your Sails instance like so:
+
+    ```js
+    // environment.js
+    ENV.APP {
+      emberDataSails: {
+        // url to your Sails instance
+        sailsHost: "https://localhost:1337"
       }
     }
     ```

--- a/README.md
+++ b/README.md
@@ -13,37 +13,47 @@ Adapters and tools for Ember to work well with Sails. Provides `SailsSocketServi
         // do something with the response
       });
     ```
-    
-    It'll use by default the `sails.io.js` located at `<hostname>:1337/js/dependencies/sails.io.js`, but you can change this using configuration in `config/environment.js` file:
-    
+
+    In order to use the `SailsSocketService`, you're application will need to load `sails.io.js`. This can be installed by running:
+
+    ```
+    bower install sails.io.js
+    ```
+
+    and then adding the following to your `Brocfile.js` or `ember-cli-build.js` (ember-cli >= 1.13):
+
+    ```js
+    app.import(app.bowerDirectory + '/sails.io.js/dist/sails.io.js');
+    ```
+
+    Alternatively, you may specify an alternative path to `sails.io.js` using the `scriptPath` property. This can be changed in your `config/environment.js` file:
+
     ```js
     ENV.APP = {
       // if you want some useful debug information related to sails
       SAILS_LOG_LEVEL: 'debug',
       emberDataSails:  {
-        // default is to use same host and port as the ember app:
-        host: '//localhost:1337',
-        // this is the default and is the path to the sails io script:
-        //scriptPath: '/js/dependencies/sails.io.js'
+        // Sails serves up sails.io.js by default at the following path
+        scriptPath: '//localhost:1337/js/dependencies/sails.io.js'
       }
     }
     ```
-    
-    Also don't forget to add the rules for CSP:
-    
+
+    Also don't forget to add the rules for CSP for wherever you script is hosted:
+
     ```js
     // allow to fetch the script
     ENV.contentSecurityPolicy['script-src'] += ' http://localhost:1337';
     // allow the websocket to connect
     ENV.contentSecurityPolicy['connect-src'] += ' http://localhost:1337 ws://localhost:1337';
     ```
-    
-    
+
+
 * `DS.SailsSocketAdapter`: use this adapter when you want to use sockets for your model(s)
 * `DS.SailsRESTAdapter`: use this adapter when you want to use sockets for your model(s)
 * `DS.SailsSerializer`: used by default when you use a Sails adapter, you shouldn't need to access it but it's there in case
 * `DS.Store.pushPayload([type], payload, [subscribe=false])`: as the original one from Ember Data, except it accepts an additional parameter which, when set to `true`, will tell the socket adapter to subscribe to the pushed records (see below)
-* `DS.Store.subscribe(type, ids)`: tells the sails socket adapter to subscribe to those models (see below) 
+* `DS.Store.subscribe(type, ids)`: tells the sails socket adapter to subscribe to those models (see below)
 
 
 ## Installation
@@ -62,7 +72,7 @@ Adapters and tools for Ember to work well with Sails. Provides `SailsSocketServi
     ```js
     // file: app/adapters/application.js
     import SailsSocketAdapter from 'ember-data-sails/adapters/sails-socket';
-    
+
     export default SailsSocketAdapter.extend({
       /**
        * Whether to use CSRF tokens or not
@@ -87,7 +97,7 @@ Adapters and tools for Ember to work well with Sails. Provides `SailsSocketServi
     ```js
     // file: app/adapters/application.js
     import SailsRESTAdapter from 'ember-data-sails/adapters/sails-rest';
-    
+
     export default SailsRESTAdapter.extend({
       /**
        * The host of your API
@@ -119,7 +129,7 @@ properties of the adapter to do a request on the API.
     * `subscribeMethod`: `get`, `post`, ... defaults to `post`
     * `subscribeEndpoint`: the endpoint to do the request on, defaults to `/socket/subscribe`
     * Of course you'll need to create a basic controller in your Sails API. Here is an example:
-    
+
         ```js
         // api/controllers/SocketController.js
         module.exports = {

--- a/addon/services/sails-socket.js
+++ b/addon/services/sails-socket.js
@@ -61,6 +61,8 @@ var SailsSocketService = Ember.Object.extend(Ember.Evented, WithLoggerMixin, {
     var script = document.getElementById('eds-sails-io-script');
     if(script) {
       return script.src.replace(/^([^:]+:\/\/[^\/]+).*$/g, '$1');
+    } else {
+      return null;
     }
   }),
 

--- a/addon/services/sails-socket.js
+++ b/addon/services/sails-socket.js
@@ -59,7 +59,9 @@ var SailsSocketService = Ember.Object.extend(Ember.Evented, WithLoggerMixin, {
    */
   socketUrl: computed(function () {
     var script = document.getElementById('eds-sails-io-script');
-    return script.src.replace(/^([^:]+:\/\/[^\/]+).*$/g, '$1');
+    if(script) {
+      return script.src.replace(/^([^:]+:\/\/[^\/]+).*$/g, '$1');
+    }
   }),
 
   /**
@@ -333,7 +335,7 @@ var SailsSocketService = Ember.Object.extend(Ember.Evented, WithLoggerMixin, {
     this.info('socket core object ready');
     this.set('isInitialized', true);
     this.trigger('didInitialize');
-    this._sailsSocket = io.sails.connect(this.get('socketUrl'));
+    this._sailsSocket = this.get('socketUrl') ? io.sails.connect(this.get('socketUrl')) : io.sails.connect();
     waitObject = bind(this, function () {
       if (this._sailsSocket._raw) {
         this._sailsSocket._raw.addEventListener('connect', bind(this, '_handleSocketConnect'));

--- a/index.js
+++ b/index.js
@@ -4,23 +4,33 @@
 module.exports = {
   name: 'ember-data-sails',
 
-  contentFor: function (what, config) {
+  contentFor: function(what, config) {
     var options;
+
+    if (config.APP && config.APP.emberDataSails) {
+      options = config.APP.emberDataSails;
+    } else {
+      options = {};
+    }
+
     if (what === 'body') {
-      if (config.APP && config.APP.emberDataSails) {
-        options = config.APP.emberDataSails;
+
+      // If scriptPath is specified, assume that the user wants to load sails.io.js from an external host.
+      if (options.scriptPath) {
+
+        return '<script type="text/javascript" id="eds-sails-io-script" src="' + options.scriptPath + '"></script>' +
+          '<script type="text/javascript">io.sails.autoConnect = false; io.sails.emberDataSailsReady = true;</script>';
       }
-      else {
-        options = {};
+    }
+
+    if (what === 'body-footer') {
+
+      // If host is not specified, assume that user wants ember-cli to package it up as part of the asset pipeline.
+      // Note that sails.io.js must be installed either manually or `bower install sails.io.js` for this to work.
+
+      if(!options.scriptPath) {
+        return '<script type="text/javascript">io.sails.autoConnect = false; io.sails.emberDataSailsReady = true;</script>';
       }
-      if (!options.host) {
-        options.host = '';
-      }
-      if (!options.scriptPath) {
-        options.scriptPath = '/js/dependencies/sails.io.js';
-      }
-      return '<script type="text/javascript" id="eds-sails-io-script" src="' + options.host + options.scriptPath + '"></script>' +
-        '<script type="text/javascript">io.sails.autoConnect = false; io.sails.emberDataSailsReady = true;</script>';
     }
   }
 };

--- a/index.js
+++ b/index.js
@@ -9,6 +9,12 @@ module.exports = {
 
     if (config.APP && config.APP.emberDataSails) {
       options = config.APP.emberDataSails;
+
+      // if no scriptPath or sailsHost is defined, default to...
+      if(!options.scriptPath && !options.sailsHost) {
+        options.scriptPath = "//localhost:1337/js/dependencies/sails.io.js";
+      }
+
     } else {
       options = {};
     }

--- a/index.js
+++ b/index.js
@@ -10,13 +10,13 @@ module.exports = {
     if (config.APP && config.APP.emberDataSails) {
       options = config.APP.emberDataSails;
 
+    } else {
+      options = {};
+
       // if no scriptPath or sailsHost is defined, default to...
       if(!options.scriptPath && !options.sailsHost) {
         options.scriptPath = "//localhost:1337/js/dependencies/sails.io.js";
       }
-
-    } else {
-      options = {};
     }
 
     if (what === 'body') {

--- a/index.js
+++ b/index.js
@@ -28,8 +28,8 @@ module.exports = {
       // If host is not specified, assume that user wants ember-cli to package it up as part of the asset pipeline.
       // Note that sails.io.js must be installed either manually or `bower install sails.io.js` for this to work.
 
-      if(!options.scriptPath) {
-        return '<script type="text/javascript">io.sails.autoConnect = false; io.sails.emberDataSailsReady = true;</script>';
+      if(!options.scriptPath && options.sailsHost) {
+        return '<script type="text/javascript">io.sails.url = "' + options.sailsHost + '";io.sails.autoConnect = false; io.sails.emberDataSailsReady = true;</script>';
       }
     }
   }

--- a/index.js
+++ b/index.js
@@ -9,33 +9,27 @@ module.exports = {
 
     if (config.APP && config.APP.emberDataSails) {
       options = config.APP.emberDataSails;
-
     } else {
       options = {};
-
-      // if no scriptPath or sailsHost is defined, default to...
-      if(!options.scriptPath && !options.sailsHost) {
-        options.scriptPath = "//localhost:1337/js/dependencies/sails.io.js";
-      }
     }
 
     if (what === 'body') {
 
-      // If scriptPath is specified, assume that the user wants to load sails.io.js from an external host.
-      if (options.scriptPath) {
+      // if loading the script from the Sails server, it's not necessary to set `io.sails.url`
+      if (!options.loadExternalScript) {
+
+        // if loadFromSails is true and host and/or scriptPath have not been set, use the Sails defaults
+        if (!options.scriptPath) {
+          options.scriptPath = "//localhost:1337/js/dependencies/sails.io.js";
+        }
 
         return '<script type="text/javascript" id="eds-sails-io-script" src="' + options.scriptPath + '"></script>' +
           '<script type="text/javascript">io.sails.autoConnect = false; io.sails.emberDataSailsReady = true;</script>';
       }
-    }
-
-    if (what === 'body-footer') {
-
-      // If host is not specified, assume that user wants ember-cli to package it up as part of the asset pipeline.
-      // Note that sails.io.js must be installed either manually or `bower install sails.io.js` for this to work.
-
-      if(!options.scriptPath && options.sailsHost) {
-        return '<script type="text/javascript">io.sails.url = "' + options.sailsHost + '";io.sails.autoConnect = false; io.sails.emberDataSailsReady = true;</script>';
+      // when loading the script from a server that IS NOT the Sails server, we need to set `io.sails.url`
+      else {
+        return '<script type="text/javascript" src="' + options.scriptPath + '"></script>' +
+          '<script type="text/javascript">io.sails.url = "' + options.sailsHost + '";io.sails.autoConnect = false; io.sails.emberDataSailsReady = true;</script>';
       }
     }
   }


### PR DESCRIPTION
The purpose of this PR is to support a local installation of `sails.io.js`. Rather than loading from an external host, the script can be installed as part of the Ember project and be treated as any other script in the Ember-CLI asset pipeline. For those that are using [ember-cli-deploy](https://github.com/ember-cli/ember-cli-deploy), such as myself, you'll get the advantage of having the script automatically deployed to your CDN.

The script still retains support for a default script path (`//localhost:1337/js/dependencies/sails.io.js`) as well as supporting any other external host through the `scriptPath` property. I removed the `host` property as it seemed unnecessary since `host` and `scriptPath` were just being concatenated.

Thanks for the great script -- keep up the good work!