### PR TITLE
Fix: passing classes to store methods was removed

### DIFF
--- a/addon/adapters/sails-socket.js
+++ b/addon/adapters/sails-socket.js
@@ -124,7 +124,7 @@ export default SailsBaseAdapter.extend({
       record.id = message.id;
     }
     payload[pluralize(camelize(type.typeKey))] = [record];
-    store.pushPayload(type, payload);
+    store.pushPayload(type.typeKey, payload);
   },
 
   /**


### PR DESCRIPTION
Fix: passing classes to store methods was removed in ember data V1.0.0-BETA.19
http://emberjs.com/blog/2015/06/05/ember-data-1-0-beta-19-released.html#toc_breaking-changes