### PR TITLE
Migrate the code to the new Ember 2.0 newSerializer code base & Errors fix

### DIFF
--- a/addon/adapters/sails-base.js
+++ b/addon/adapters/sails-base.js
@@ -107,10 +107,7 @@ export default DS.RESTAdapter.extend(Ember.Evented, WithLoggerMixin, {
           this.debug('  → request:', options.data);
           this.debug('  ← response:', response);
           if (this.isErrorObject(response)) {
-            if (response.errors) {
-              return RSVP.reject(new DS.InvalidError(this.formatError(response)));
-            }
-            return RSVP.reject(response);
+            return RSVP.reject(new DS.InvalidError(this.formatError(response)));
           }
           return response;
         }))
@@ -149,7 +146,7 @@ export default DS.RESTAdapter.extend(Ember.Evented, WithLoggerMixin, {
       data = jqXHR.responseText;
     }
 
-    if (data.errors) {
+    if (this.isErrorObject(data)) {
       this.error('error returned from Sails', data);
       return new DS.InvalidError(this.formatError(data));
     }

--- a/addon/adapters/sails-rest.js
+++ b/addon/adapters/sails-rest.js
@@ -20,26 +20,30 @@ export default SailsBaseAdapter.extend({
    * @property csrfTokenUrl
    * @type String
    */
-  csrfTokenUrl: computed('host', 'namespace', 'csrfTokenPath', function (key, value) {
-    var csrfTokenUrl, csrfTokenPath;
-    if (arguments.length > 1) {
-      this._csrfTokenUrl = csrfTokenUrl = value;
-    }
-    else if (this._csrfTokenUrl !== undefined) {
-      csrfTokenUrl = this._csrfTokenUrl;
-    }
-    else {
-      csrfTokenPath = this.get('csrfTokenPath');
-      csrfTokenUrl = Ember.A([
-        this.get('host'),
-        csrfTokenPath.charAt(0) === '/' ? null : this.get('namespace'),
-        csrfTokenPath.replace(/^\//, '')
-      ]).filter(Boolean).join('/');
-      if (!/^(https?:)?\/\//.test(csrfTokenUrl)) {
-        csrfTokenUrl = '/' + csrfTokenUrl;
+  csrfTokenUrl: computed('host', 'namespace', 'csrfTokenPath',{
+    get(key) {
+      var csrfTokenUrl, csrfTokenPath;
+      if (this._csrfTokenUrl !== undefined) {
+        csrfTokenUrl = this._csrfTokenUrl;
       }
+      else {
+        csrfTokenPath = this.get('csrfTokenPath');
+        csrfTokenUrl = Ember.A([
+          this.get('host'),
+          csrfTokenPath.charAt(0) === '/' ? null : this.get('namespace'),
+          csrfTokenPath.replace(/^\//, '')
+        ]).filter(Boolean).join('/');
+        if (!/^(https?:)?\/\//.test(csrfTokenUrl)) {
+          csrfTokenUrl = '/' + csrfTokenUrl;
+        }
+      }
+      return csrfTokenUrl;
+    },
+    set(key, value) {
+      this._csrfTokenUrl = value;
+      return this._csrfTokenUrl;
     }
-    return csrfTokenUrl;
+
   }),
 
 

--- a/addon/serializers/sails.js
+++ b/addon/serializers/sails.js
@@ -23,6 +23,9 @@ function blueprintsWrapMethod(method) {
  * @extends DS.RESTSerializer
  */
 var SailsSerializer = DS.RESTSerializer.extend(WithLogger, {
+
+  isNewSerializerAPI: true,
+
   /**
    * The config of the addon will be set here by the initializer
    * @since 0.0.17
@@ -44,7 +47,7 @@ var SailsSerializer = DS.RESTSerializer.extend(WithLogger, {
    * @method extractArray
    * @inheritDoc
    */
-  extractArray: blueprintsWrapMethod(function (store, primaryType, payload) {
+  normalizeArrayResponse: blueprintsWrapMethod(function (store, primaryType, payload) {
     var newPayload = {};
     newPayload[pluralize(primaryType.modelName)] = payload;
     return this._super(store, primaryType, newPayload);
@@ -55,7 +58,7 @@ var SailsSerializer = DS.RESTSerializer.extend(WithLogger, {
    * @method extractSingle
    * @inheritDoc
    */
-  extractSingle: blueprintsWrapMethod(function (store, primaryType, payload, recordId) {
+  normalizeSingleResponse: blueprintsWrapMethod(function (store, primaryType, payload, recordId) {
     var newPayload;
     if (payload === null) {
       return this._super.apply(this, arguments);
@@ -70,7 +73,7 @@ var SailsSerializer = DS.RESTSerializer.extend(WithLogger, {
    * @method extractDeleteRecord
    * @inheritDoc
    */
-  extractDeleteRecord: blueprintsWrapMethod(function (store, type, payload, id, requestType) {
+  normalizeDeleteRecordResponse: blueprintsWrapMethod(function (store, type, payload, id, requestType) {
     return this._super(store, type, null, id, requestType);
   }),
 
@@ -108,7 +111,7 @@ var SailsSerializer = DS.RESTSerializer.extend(WithLogger, {
    * @method extract
    * @inheritDoc
    */
-  extract: function (store, type/*, payload, id, requestType*/) {
+  normalizeResponse: function (store, type/*, payload, id, requestType*/) {
     var adapter, modelName, isUsingSocketAdapter;
     // this is the only place we have access to the store, so that we can get the adapter and check
     // if it is an instance of sails socket adapter, and so register for events if necessary on that
@@ -118,7 +121,7 @@ var SailsSerializer = DS.RESTSerializer.extend(WithLogger, {
     }
     modelName = type.modelName;
     if (this._modelsUsingSailsSocketAdapter[modelName] === undefined) {
-      adapter = store.adapterFor(type);
+      adapter = store.adapterFor(modelName);
       this._modelsUsingSailsSocketAdapter[modelName] = isUsingSocketAdapter = adapter instanceof SailsSocketAdapter;
       if (isUsingSocketAdapter) {
         adapter._listenToSocket(modelName);


### PR DESCRIPTION
I've migrated the code to work with Ember 2.0 and the new Ember Data (normalizeResponse instead of all the extract hooks).  

I've also fixes the errors handling from the Sails server that wasn't working - no .errors property is returned, only an .error. So I moved the code to use isErrorObject function you've already implemented.