### PR TITLE
Passing classes to store methods has been removed.

### DIFF
--- a/addon/mixins/store.js
+++ b/addon/mixins/store.js
@@ -18,6 +18,7 @@ var StoreMixin = Ember.Mixin.create({
       sub = args.pop();
     }
     this._pushSubscribes = sub;
+    args[0] = args[0].toString().slice(0, -1);
     this._super.apply(this, args);
     this._pushSubscribes = old;
   },


### PR DESCRIPTION
Uncaught Error: Assertion Failed: Passing classes to store methods has
been removed. Please pass a dasherized string instead of
"<app_name>@model:<model_name>:" removing trailing ':' makes it work, at
least